### PR TITLE
Prefer `/proc` over `ps` on Linux for general metrics.

### DIFF
--- a/lib/process/metrics/general/linux.rb
+++ b/lib/process/metrics/general/linux.rb
@@ -51,14 +51,14 @@ module Process
 					
 					comm = stat[1...rparen]
 					fields = stat[(rparen + 2)..].split(/\s+/)
-					# After comm: state(3), ppid(4), pgrp(5), ... utime(14), stime(15), ... starttime(22), vsz(23), rss(24). 0-based: ppid=1, pgrp=2, utime=11, stime=12, starttime=20, vsz=21, rss=22
+					# After comm: state(3), ppid(4), pgrp(5), ... utime(14), stime(15), ... starttime(22), vsz(23), rss(24). 0-based: ppid=1, pgrp=2, utime=11, stime=12, starttime=19, vsz=20, rss=21.
 					ppid_val = fields[1].to_i
 					pgrp = fields[2].to_i
 					utime = fields[11].to_i
 					stime = fields[12].to_i
-					starttime = fields[20].to_i
-					vsz = fields[21].to_i
-					rss_pages = fields[22].to_i
+					starttime = fields[19].to_i
+					vsz = fields[20].to_i
+					rss_pages = fields[21].to_i
 					
 					# Read /proc/uptime once per capture and reuse for every process (starttime is in jiffies since boot).
 					uptime_jiffies ||= begin

--- a/lib/process/metrics/general/linux.rb
+++ b/lib/process/metrics/general/linux.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2019-2026, by Samuel Williams.
+
+require "etc"
+
+module Process
+	module Metrics
+		# General process information by reading /proc. Used on Linux to avoid spawning `ps`.
+		# We read directly from the kernel (proc(5)) so there is no subprocess and no parsing of
+		# external command output; same data source as the kernel uses for process accounting.
+		# Parses /proc/[pid]/stat and /proc/[pid]/cmdline for each process.
+		module General::Linux
+			# Clock ticks per second for /proc stat times (utime, stime, starttime).
+			CLK_TCK = Etc.sysconf(Etc::SC_CLK_TCK) rescue 100
+			
+			# Page size in bytes for RSS (resident set size is in pages in /proc/pid/stat).
+			PAGE_SIZE = Etc.sysconf(Etc::SC_PAGESIZE) rescue 4096
+			
+			# Whether /proc is available so we can list processes without ps.
+			def self.supported?
+				File.directory?("/proc") && File.readable?("/proc/self/stat")
+			end
+			
+			# Capture process information from /proc. If given `pid`, captures only those process(es). If given `ppid`, captures that parent and all descendants. Both can be given to capture a process and its children.
+			# @parameter pid [Integer | Array(Integer)] Process ID(s) to capture.
+			# @parameter ppid [Integer | Array(Integer)] Parent process ID(s) to include children for.
+			# @parameter memory [Boolean] Whether to capture detailed memory metrics (default: Memory.supported?).
+			# @returns [Hash<Integer, General>] Map of PID to General instance.
+			def self.capture(pid: nil, ppid: nil, memory: Memory.supported?)
+				# When filtering by ppid we need the full process list to build the parent-child tree,
+				# so we enumerate all numeric /proc entries; when only pid is set we read just those.
+				pids_to_read = if pid && ppid.nil?
+					Array(pid)
+				else
+					Dir.children("/proc").filter{|e| e.match?(/\A\d+\z/)}.map(&:to_i)
+				end
+				
+				uptime_jiffies = nil
+				
+				processes = {}
+				pids_to_read.each do |p|
+					stat_path = "/proc/#{p}/stat"
+					next unless File.readable?(stat_path)
+					
+					stat = File.read(stat_path)
+					# comm field can contain spaces and parentheses; find the closing ')' (proc(5)).
+					rparen = stat.rindex(")")
+					next unless rparen
+					
+					comm = stat[1...rparen]
+					fields = stat[(rparen + 2)..].split(/\s+/)
+					# After comm: state(3), ppid(4), pgrp(5), ... utime(14), stime(15), ... starttime(22), vsz(23), rss(24). 0-based: ppid=1, pgrp=2, utime=11, stime=12, starttime=20, vsz=21, rss=22
+					ppid_val = fields[1].to_i
+					pgrp = fields[2].to_i
+					utime = fields[11].to_i
+					stime = fields[12].to_i
+					starttime = fields[20].to_i
+					vsz = fields[21].to_i
+					rss_pages = fields[22].to_i
+					
+					# Read /proc/uptime once per capture and reuse for every process (starttime is in jiffies since boot).
+					uptime_jiffies ||= begin
+						uptime_seconds = File.read("/proc/uptime").split(/\s+/).first.to_f
+						(uptime_seconds * CLK_TCK).to_i
+					end
+					
+					processor_time = (utime + stime).to_f / CLK_TCK
+					elapsed_time = [(uptime_jiffies - starttime).to_f / CLK_TCK, 0.0].max
+					
+					command = read_command(p, comm)
+					
+					processes[p] = General.new(
+						p,
+						ppid_val,
+						pgrp,
+						0.0, # processor_utilization: would need two samples; not available from single stat read
+						vsz,
+						rss_pages * PAGE_SIZE,
+						processor_time,
+						elapsed_time,
+						command,
+						nil
+					)
+				rescue Errno::ENOENT, Errno::ESRCH, Errno::EACCES
+					# Process disappeared or we can't read it.
+					next
+				end
+				
+				# Restrict to the requested pid/ppid subtree using the same tree logic as the ps backend.
+				if ppid
+					pids = Set.new
+					hierarchy = General.build_tree(processes)
+					General.expand_children(Array(pid), hierarchy, pids) if pid
+					General.expand_children(Array(ppid), hierarchy, pids)
+					processes.select!{|p, _| pids.include?(p)}
+				end
+				
+				General.capture_memory(processes) if memory
+				
+				processes
+			end
+			
+			# Read command line from /proc/[pid]/cmdline; fall back to comm from stat if empty.
+			# Use binread because cmdline is NUL-separated and may contain non-UTF-8 bytes; we split on NUL and join for display.
+			def self.read_command(pid, comm_fallback)
+				path = "/proc/#{pid}/cmdline"
+				return comm_fallback unless File.readable?(path)
+				
+				raw = File.binread(path)
+				return comm_fallback if raw.empty?
+				
+				# cmdline is NUL-separated; replace with spaces for display.
+				raw.split("\0").join(" ").strip
+			rescue Errno::ENOENT, Errno::ESRCH, Errno::EACCES
+				comm_fallback
+			end
+		end
+	end
+end
+
+if Process::Metrics::General::Linux.supported?
+	class << Process::Metrics::General
+		def capture(...)
+			Process::Metrics::General::Linux.capture(...)
+		end
+	end
+end

--- a/lib/process/metrics/general/process_status.rb
+++ b/lib/process/metrics/general/process_status.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2019-2026, by Samuel Williams.
+
+module Process
+	module Metrics
+		# General process information via the process status command (`ps`). Used on non-Linux platforms (e.g. Darwin)
+		# where there is no /proc; ps is the portable way to get pid, ppid, times, and memory in one pass.
+		module General::ProcessStatus
+			PS = "ps"
+			
+			# The fields that will be extracted from the `ps` command (order matches -o output).
+			FIELDS = {
+				pid: ->(value){value.to_i},
+				ppid: ->(value){value.to_i},
+				pgid: ->(value){value.to_i},
+				pcpu: ->(value){value.to_f},
+				vsz: ->(value){value.to_i * 1024},
+				rss: ->(value){value.to_i * 1024},
+				time: Process::Metrics.method(:duration),
+				etime: Process::Metrics.method(:duration),
+				command: ->(value){value},
+			}
+			
+			# Whether process listing via ps is available on this system.
+			def self.supported?
+				which = ENV["PATH"]&.split(File::PATH_SEPARATOR)&.find{|dir| File.executable?(File.join(dir, PS))}
+				!!which
+			end
+			
+			# Capture process information using ps. If given a `pid`, captures that process; if given `ppid`, captures that process and all descendants. Specify both to capture a process and its children.
+			# @parameter pid [Integer | Array(Integer)] Process ID(s) to capture.
+			# @parameter ppid [Integer | Array(Integer)] Parent process ID(s) to include children for.
+			# @parameter memory [Boolean] Whether to capture detailed memory metrics (default: Memory.supported?).
+			# @returns [Hash<Integer, General>] Map of PID to General instance.
+			def self.capture(pid: nil, ppid: nil, memory: Memory.supported?)
+				ps_pid = nil
+				
+				header, *lines = IO.pipe do |input, output|
+					arguments = [PS]
+					
+					# When filtering by ppid we need the full process list to build the tree, so use "ax"; otherwise limit to -p.
+					if pid && ppid.nil?
+						arguments.push("-p", Array(pid).join(","))
+					else
+						arguments.push("ax")
+					end
+					
+					arguments.push("-o", FIELDS.keys.join(","))
+					
+					ps_pid = Process.spawn(*arguments, out: output)
+					output.close
+					
+					input.readlines.map(&:strip)
+				ensure
+					input.close
+					
+					# Always kill and reap the ps subprocess so we never leave it hanging if the pipe closes early.
+					if ps_pid
+						begin
+							Process.kill(:KILL, ps_pid)
+							Process.wait(ps_pid)
+						rescue => error
+							warn "Failed to cleanup ps process #{ps_pid}:\n#{error.full_message}"
+						end
+					end
+				end
+				
+				processes = {}
+				
+				lines.each do |line|
+					next if line.empty?
+					
+					values = line.split(/\s+/, FIELDS.size)
+					next if values.size < FIELDS.size
+					
+					record = FIELDS.keys.map.with_index{|key, i| FIELDS[key].call(values[i])}
+					instance = General.new(*record, nil)
+					processes[instance.process_id] = instance
+				end
+				
+				# Restrict to the requested pid/ppid subtree; exclude our own ps process from the result.
+				if ppid
+					pids = Set.new
+					hierarchy = General.build_tree(processes)
+					General.expand_children(Array(pid), hierarchy, pids) if pid
+					General.expand_children(Array(ppid), hierarchy, pids)
+					processes.select!{|p, _| p != ps_pid && pids.include?(p)}
+				else
+					processes.delete(ps_pid) if ps_pid
+				end
+				
+				General.capture_memory(processes) if memory
+				
+				processes
+			end
+		end
+	end
+end
+
+# Wire General.capture to ProcessStatus only when Linux backend isn't active (so Linux can load both for comparison tests).
+if Process::Metrics::General::ProcessStatus.supported?
+	wire_ps = !RUBY_PLATFORM.include?("linux") ||
+		!defined?(Process::Metrics::General::Linux) ||
+		!Process::Metrics::General::Linux.supported?
+	if wire_ps
+		class << Process::Metrics::General
+			def capture(...)
+				Process::Metrics::General::ProcessStatus.capture(...)
+			end
+		end
+	end
+end

--- a/lib/process/metrics/host/memory/darwin.rb
+++ b/lib/process/metrics/host/memory/darwin.rb
@@ -10,18 +10,18 @@ module Process
 			# Uses sysctl (hw.memsize), vm_stat (free + inactive pages), and vm.swapusage for swap.
 			class Memory::Darwin
 				# Parse a size string from vm.swapusage (e.g. "1024.00M", "512.00K") into bytes.
-				# @parameter string [String | Nil] The size string from sysctl vm.swapusage.
-				# @returns [Integer | Nil] Size in bytes, or nil if string is nil/empty.
-				def self.parse_swap_size(string)
-					return nil unless string
+				# @parameter size_string [String | Nil] The size string from sysctl vm.swapusage.
+				# @returns [Integer | Nil] Size in bytes, or nil if size_string is nil/empty.
+				def self.parse_swap_size(size_string)
+					return nil unless size_string
 					
-					string = string.strip
+					size_string = size_string.strip
 					
-					case string
+					case size_string
 					when /([\d.]+)M/i then ($1.to_f * 1024 * 1024).round
 					when /([\d.]+)G/i then ($1.to_f * 1024 * 1024 * 1024).round
 					when /([\d.]+)K/i then ($1.to_f * 1024).round
-					else string.to_f.round
+					else size_string.to_f.round
 					end
 				end
 				

--- a/lib/process/metrics/host/memory/linux.rb
+++ b/lib/process/metrics/host/memory/linux.rb
@@ -61,11 +61,11 @@ module Process
 						return limit if limit > 0 && limit < CGROUP_V1_UNLIMITED_THRESHOLD
 					end
 					
-					unless meminfo = self.meminfo
-						return nil 
+					unless meminfo_content = self.meminfo
+						return nil
 					end
 					
-					meminfo.each_line do |line|
+					meminfo_content.each_line do |line|
 						if /MemTotal:\s*(?<total>\d+)\s*kB/ =~ line
 							return $~[:total].to_i * 1024
 						end
@@ -90,28 +90,28 @@ module Process
 						end
 					end
 					
-					unless meminfo = self.meminfo
-						return nil 
+					unless meminfo_content = self.meminfo
+						return nil
 					end
 					
-					available_kb = meminfo[/MemAvailable:\s*(\d+)\s*kB/, 1]&.to_i
-					available_kb ||= meminfo[/MemFree:\s*(\d+)\s*kB/, 1]&.to_i
-					return nil unless available_kb
+					available_kilobytes = meminfo_content[/MemAvailable:\s*(\d+)\s*kB/, 1]&.to_i
+					available_kilobytes ||= meminfo_content[/MemFree:\s*(\d+)\s*kB/, 1]&.to_i
+					return nil unless available_kilobytes
 					
-					return [total - (available_kb * 1024), 0].max
+					return [total - (available_kilobytes * 1024), 0].max
 				end
 				
 				# Swap total and used in bytes from meminfo (SwapTotal, SwapFree).
 				# @returns [Array(Integer, Integer)] [swap_total_bytes, swap_used_bytes], or [nil, nil] if no swap.
 				def capture_swap
-					return [nil, nil] unless meminfo
-					swap_total_kb = meminfo[/SwapTotal:\s*(\d+)\s*kB/, 1]&.to_i
-					swap_free_kb = meminfo[/SwapFree:\s*(\d+)\s*kB/, 1]&.to_i
+					return [nil, nil] unless meminfo_content = self.meminfo
+					swap_total_kilobytes = meminfo_content[/SwapTotal:\s*(\d+)\s*kB/, 1]&.to_i
+					swap_free_kilobytes = meminfo_content[/SwapFree:\s*(\d+)\s*kB/, 1]&.to_i
 					
-					return [nil, nil] unless swap_total_kb
+					return [nil, nil] unless swap_total_kilobytes
 					
-					swap_total_bytes = swap_total_kb * 1024
-					swap_used_bytes = (swap_total_kb - (swap_free_kb || 0)) * 1024
+					swap_total_bytes = swap_total_kilobytes * 1024
+					swap_used_bytes = (swap_total_kilobytes - (swap_free_kilobytes || 0)) * 1024
 					
 					return swap_total_bytes, swap_used_bytes
 				end

--- a/lib/process/metrics/memory/darwin.rb
+++ b/lib/process/metrics/memory/darwin.rb
@@ -16,16 +16,16 @@ module Process
 			end
 			
 			# Parse a size string from vmmap (e.g. "4K", "1.5M", "2G") into bytes.
-			# @parameter string [String | Nil]
+			# @parameter size_string [String | Nil]
 			# @returns [Integer]
-			def self.parse_size(string)
-				return 0 unless string
+			def self.parse_size(size_string)
+				return 0 unless size_string
 				
-				case string.strip
+				case size_string.strip
 				when /([\d\.]+)K/i then ($1.to_f * 1024).round
 				when /([\d\.]+)M/i then ($1.to_f * 1024 * 1024).round
 				when /([\d\.]+)G/i then ($1.to_f * 1024 * 1024 * 1024).round
-				else (string.to_f).ceil
+				else (size_string.to_f).ceil
 				end
 			end
 			

--- a/lib/process/metrics/memory/linux.rb
+++ b/lib/process/metrics/memory/linux.rb
@@ -12,11 +12,11 @@ module Process
 			# @parameter pid [Integer] Process ID.
 			# @parameter usage [Memory] Memory instance to populate with minor_faults and major_faults.
 			def self.capture_faults(pid, usage)
-				stat = File.read("/proc/#{pid}/stat")
+				stat_content = File.read("/proc/#{pid}/stat")
 				# The comm field can contain spaces and parentheses; find the closing ')':
-				rparen_index = stat.rindex(")")
-				return unless rparen_index
-				fields = stat[(rparen_index+2)..-1].split(/\s+/)
+				closing_paren_index = stat_content.rindex(")")
+				return unless closing_paren_index
+				fields = stat_content[(closing_paren_index + 2)..].split(/\s+/)
 				# proc(5): field 10=minflt, 12=majflt; our fields array is 0-indexed from field 3.
 				usage.minor_faults = fields[10-3].to_i
 				usage.major_faults = fields[12-3].to_i

--- a/test/process/general.rb
+++ b/test/process/general.rb
@@ -28,8 +28,38 @@ describe Process::Metrics::General do
 		it "can extract memory usage" do
 			expect(capture[pid].memory_usage).to be > 0.0
 		end
+
+		it "sets parent_process_id and process_group_id" do
+			process = capture[pid]
+			expect(process.process_id).to be == pid
+			expect(process.parent_process_id).to be_a(Integer)
+			expect(process.process_group_id).to be_a(Integer)
+		end
 	end
-	
+
+	with ".capture with ppid only" do
+		def before
+			super
+			@child_pid = Process.spawn("sleep 10")
+		end
+
+		def after(error = nil)
+			super
+			Process.kill(:TERM, @child_pid) if @child_pid
+			Process.wait(@child_pid) if @child_pid
+		end
+
+		let(:capture) { Process::Metrics::General.capture(ppid: Process.pid) }
+
+		it "includes descendants of the given ppid" do
+			expect(capture).to be(:include?, @child_pid)
+			child = capture[@child_pid]
+			expect(child).not.to be_nil
+			expect(child.command).to be(:include?, "sleep")
+			expect(child.parent_process_id).to be == Process.pid
+		end
+	end
+
 	with ".capture with parent pid" do
 		def before
 			super
@@ -61,6 +91,13 @@ describe Process::Metrics::General do
 			expect(command[:elapsed_time]).to be >= 0.0
 			expect(command[:processor_time]).to be >= 0.0
 			expect(command[:processor_utilization]).to be >= 0.0
+		end
+
+		it "sets parent_process_id and process_group_id on child" do
+			child = capture[@pid]
+			expect(child).not.to be_nil
+			expect(child.parent_process_id).to be_a(Integer)
+			expect(child.process_group_id).to be_a(Integer)
 		end
 	end
 end

--- a/test/process/general.rb
+++ b/test/process/general.rb
@@ -28,7 +28,7 @@ describe Process::Metrics::General do
 		it "can extract memory usage" do
 			expect(capture[pid].memory_usage).to be > 0.0
 		end
-
+		
 		it "sets parent_process_id and process_group_id" do
 			process = capture[pid]
 			expect(process.process_id).to be == pid
@@ -36,21 +36,21 @@ describe Process::Metrics::General do
 			expect(process.process_group_id).to be_a(Integer)
 		end
 	end
-
+	
 	with ".capture with ppid only" do
 		def before
 			super
 			@child_pid = Process.spawn("sleep 10")
 		end
-
+		
 		def after(error = nil)
 			super
 			Process.kill(:TERM, @child_pid) if @child_pid
 			Process.wait(@child_pid) if @child_pid
 		end
-
-		let(:capture) { Process::Metrics::General.capture(ppid: Process.pid) }
-
+		
+		let(:capture) {Process::Metrics::General.capture(ppid: Process.pid)}
+		
 		it "includes descendants of the given ppid" do
 			expect(capture).to be(:include?, @child_pid)
 			child = capture[@child_pid]
@@ -59,7 +59,7 @@ describe Process::Metrics::General do
 			expect(child.parent_process_id).to be == Process.pid
 		end
 	end
-
+	
 	with ".capture with parent pid" do
 		def before
 			super
@@ -92,7 +92,7 @@ describe Process::Metrics::General do
 			expect(command[:processor_time]).to be >= 0.0
 			expect(command[:processor_utilization]).to be >= 0.0
 		end
-
+		
 		it "sets parent_process_id and process_group_id on child" do
 			child = capture[@pid]
 			expect(child).not.to be_nil

--- a/test/process/general/linux.rb
+++ b/test/process/general/linux.rb
@@ -9,45 +9,45 @@ require "process/metrics/general/process_status"
 
 describe Process::Metrics::General do
 	with "Linux backend matches ProcessStatus backend" do
-		def assert_backends_match(linux, ps)
-			expect(linux.keys.sort).to be == ps.keys.sort
+		def assert_backends_match(linux_capture, process_status_capture)
+			expect(linux_capture.keys.sort).to be == process_status_capture.keys.sort
 			
-			linux.each_key do |pid|
-				linux_process = linux[pid]
-				ps_process = ps[pid]
+			linux_capture.each_key do |pid|
+				linux_process = linux_capture[pid]
+				process_status_process = process_status_capture[pid]
 				
-				expect(ps_process).not.to be_nil
-				expect(linux_process.process_id).to be == ps_process.process_id
-				expect(linux_process.parent_process_id).to be == ps_process.parent_process_id
-				expect(linux_process.process_group_id).to be == ps_process.process_group_id
+				expect(process_status_process).not.to be_nil
+				expect(linux_process.process_id).to be == process_status_process.process_id
+				expect(linux_process.parent_process_id).to be == process_status_process.parent_process_id
+				expect(linux_process.process_group_id).to be == process_status_process.process_group_id
 				
 				# VSZ and RSS differ because ps excludes device mappings while /proc/stat includes them.
-				expect(linux_process.virtual_size).to be_within(10.0).percent_of(ps_process.virtual_size)
-				expect(linux_process.resident_size).to be_within(10.0).percent_of(ps_process.resident_size)
+				expect(linux_process.virtual_size).to be_within(10.0).percent_of(process_status_process.virtual_size)
+				expect(linux_process.resident_size).to be_within(10.0).percent_of(process_status_process.resident_size)
 				
-				expect(linux_process.command).to be == ps_process.command
-				expect((linux_process.processor_time - ps_process.processor_time).abs).to be < 1.0
-				expect((linux_process.elapsed_time - ps_process.elapsed_time).abs).to be < 1.0
+				expect(linux_process.command).to be == process_status_process.command
+				expect((linux_process.processor_time - process_status_process.processor_time).abs).to be < 1.0
+				expect((linux_process.elapsed_time - process_status_process.elapsed_time).abs).to be < 1.0
 			end
 		end
 		
 		it "single pid capture matches" do
-			skip "Linux with ps required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
+			skip "Linux with ProcessStatus required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
 			
 			pid = Process.pid
-			linux = Process::Metrics::General.capture(pid: pid, memory: false)
-			ps = Process::Metrics::General::ProcessStatus.capture(pid: pid, memory: false)
-			assert_backends_match(linux, ps)
+			linux_capture = Process::Metrics::General.capture(pid: pid, memory: false)
+			process_status_capture = Process::Metrics::General::ProcessStatus.capture(pid: pid, memory: false)
+			assert_backends_match(linux_capture, process_status_capture)
 		end
 		
 		it "pid and ppid capture matches" do
-			skip "Linux with ps required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
+			skip "Linux with ProcessStatus required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
 			
 			child_pid = Process.spawn("sleep 10")
 			begin
-				linux = Process::Metrics::General.capture(pid: child_pid, ppid: child_pid, memory: false)
-				ps = Process::Metrics::General::ProcessStatus.capture(pid: child_pid, ppid: child_pid, memory: false)
-				assert_backends_match(linux, ps)
+				linux_capture = Process::Metrics::General.capture(pid: child_pid, ppid: child_pid, memory: false)
+				process_status_capture = Process::Metrics::General::ProcessStatus.capture(pid: child_pid, ppid: child_pid, memory: false)
+				assert_backends_match(linux_capture, process_status_capture)
 			ensure
 				Process.kill(:TERM, child_pid)
 				Process.wait(child_pid)

--- a/test/process/general/linux.rb
+++ b/test/process/general/linux.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024-2025, by Samuel Williams.
+
+require "process/metrics"
+# Load ProcessStatus backend so we can compare General (Linux) vs General::ProcessStatus.
+require "process/metrics/general/process_status"
+
+describe Process::Metrics::General do
+	with "Linux backend matches ProcessStatus backend" do
+		def assert_backends_match(linux, ps)
+			expect(linux.keys.sort).to be == ps.keys.sort
+			
+			linux.each_key do |pid|
+				linux_process = linux[pid]
+				ps_process = ps[pid]
+				
+				expect(ps_process).not.to be_nil
+				expect(linux_process.process_id).to be == ps_process.process_id
+				expect(linux_process.parent_process_id).to be == ps_process.parent_process_id
+				expect(linux_process.process_group_id).to be == ps_process.process_group_id
+				
+				# VSZ and RSS differ because ps excludes device mappings while /proc/stat includes them.
+				expect(linux_process.virtual_size).to be_within(10.0).percent_of(ps_process.virtual_size)
+				expect(linux_process.resident_size).to be_within(10.0).percent_of(ps_process.resident_size)
+				
+				expect(linux_process.command).to be == ps_process.command
+				expect((linux_process.processor_time - ps_process.processor_time).abs).to be < 1.0
+				expect((linux_process.elapsed_time - ps_process.elapsed_time).abs).to be < 1.0
+			end
+		end
+		
+		it "single pid capture matches" do
+			skip "Linux with ps required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
+			
+			pid = Process.pid
+			linux = Process::Metrics::General.capture(pid: pid, memory: false)
+			ps = Process::Metrics::General::ProcessStatus.capture(pid: pid, memory: false)
+			assert_backends_match(linux, ps)
+		end
+		
+		it "pid and ppid capture matches" do
+			skip "Linux with ps required" unless RUBY_PLATFORM.include?("linux") && Process::Metrics::General::ProcessStatus.supported?
+			
+			child_pid = Process.spawn("sleep 10")
+			begin
+				linux = Process::Metrics::General.capture(pid: child_pid, ppid: child_pid, memory: false)
+				ps = Process::Metrics::General::ProcessStatus.capture(pid: child_pid, ppid: child_pid, memory: false)
+				assert_backends_match(linux, ps)
+			ensure
+				Process.kill(:TERM, child_pid)
+				Process.wait(child_pid)
+			end
+		end
+	end
+end


### PR DESCRIPTION
There have been some reports of people deploying to infrastructure which doesn't have `ps` or has a version of `ps` without all the fields. On Linux, we can just use `/proc` directly.

Fixes <https://github.com/socketry/falcon/issues/337>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
