### PR TITLE
Improve host memory documentation coverage

### DIFF
--- a/lib/process/metrics/host/memory.rb
+++ b/lib/process/metrics/host/memory.rb
@@ -15,12 +15,17 @@ module Process
 			# @attribute swap_used_size [Integer, nil] Swap in use, or nil if not available.
 			# @attribute reclaimable_size [Integer, nil] Reclaimable memory (e.g. page cache, slab), or nil. Included in used_size.
 			Memory = Struct.new(:total_size, :used_size, :swap_total_size, :swap_used_size, :reclaimable_size) do
+				# Convert the memory snapshot to a hash, including derived sizes.
+				# @returns [Hash(Symbol, Integer | Nil)] The memory snapshot fields.
 				def to_h
 					super.merge(free_size: free_size, available_size: available_size)
 				end
 				
 				alias as_json to_h
 				
+				# Convert the memory snapshot to JSON.
+				# @parameter arguments [Array] Additional arguments passed to the JSON encoder.
+				# @returns [String] The encoded memory snapshot.
 				def to_json(*arguments)
 					as_json.to_json(*arguments)
 				end

--- a/lib/process/metrics/host/memory/linux.rb
+++ b/lib/process/metrics/host/memory/linux.rb
@@ -10,6 +10,9 @@ module Process
 			module Memory::Linux
 				DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
 				
+				# Capture host memory from the available Linux interface.
+				# @parameter cgroup_root [String] The root of the cgroup filesystem.
+				# @returns [Host::Memory | Nil] The captured host memory, if available.
 				def self.capture(cgroup_root: DEFAULT_CGROUP_ROOT)
 					if Memory::Linux::CgroupV2.supported?(cgroup_root)
 						if capture = Memory::Linux::CgroupV2.new(cgroup_root: cgroup_root).capture

--- a/lib/process/metrics/host/memory/linux/cgroup_v1.rb
+++ b/lib/process/metrics/host/memory/linux/cgroup_v1.rb
@@ -6,10 +6,14 @@
 module Process
 	module Metrics
 		module Host
+			# Captures host memory limits and usage from a cgroup v1 filesystem.
 			class Memory::Linux::CgroupV1
 				CGROUP_V1_UNLIMITED_THRESHOLD = 2**60
 				DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
 				
+				# Whether cgroup v1 memory metrics are available.
+				# @parameter cgroup_root [String | Nil] The root of the cgroup filesystem.
+				# @returns [Boolean] Whether the required cgroup v1 files exist.
 				def self.supported?(cgroup_root = DEFAULT_CGROUP_ROOT)
 					root = (cgroup_root || DEFAULT_CGROUP_ROOT).to_s.chomp("/")
 					
@@ -20,10 +24,14 @@ module Process
 					return false
 				end
 				
+				# Initialize the cgroup v1 memory reader.
+				# @parameter cgroup_root [String | Nil] The root of the cgroup filesystem.
 				def initialize(cgroup_root: nil)
 					@cgroup_root = (cgroup_root || DEFAULT_CGROUP_ROOT).to_s.chomp("/")
 				end
 				
+				# Capture host memory from the cgroup v1 filesystem.
+				# @returns [Host::Memory | Nil] The captured host memory, if the cgroup has a finite limit.
 				def capture
 					total = read_total
 					return nil unless total && total.positive?

--- a/lib/process/metrics/host/memory/linux/cgroup_v2.rb
+++ b/lib/process/metrics/host/memory/linux/cgroup_v2.rb
@@ -6,9 +6,13 @@
 module Process
 	module Metrics
 		module Host
+			# Captures host memory limits and usage from a cgroup v2 filesystem.
 			class Memory::Linux::CgroupV2
 				DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup"
 				
+				# Whether cgroup v2 memory metrics are available.
+				# @parameter cgroup_root [String | Nil] The root of the cgroup filesystem.
+				# @returns [Boolean] Whether the required cgroup v2 files exist.
 				def self.supported?(cgroup_root = DEFAULT_CGROUP_ROOT)
 					root = (cgroup_root || DEFAULT_CGROUP_ROOT).to_s.chomp("/")
 					
@@ -19,10 +23,14 @@ module Process
 					return false
 				end
 				
+				# Initialize the cgroup v2 memory reader.
+				# @parameter cgroup_root [String | Nil] The root of the cgroup filesystem.
 				def initialize(cgroup_root: nil)
 					@cgroup_root = (cgroup_root || DEFAULT_CGROUP_ROOT).to_s.chomp("/")
 				end
 				
+				# Capture host memory from the cgroup v2 filesystem.
+				# @returns [Host::Memory | Nil] The captured host memory, if the cgroup has a finite limit.
 				def capture
 					total = read_total
 					return nil unless total && total.positive?

--- a/lib/process/metrics/host/memory/linux/meminfo.rb
+++ b/lib/process/metrics/host/memory/linux/meminfo.rb
@@ -6,11 +6,16 @@
 module Process
 	module Metrics
 		module Host
+			# Captures host memory from Linux `/proc/meminfo`.
 			class Memory::Linux::Meminfo
+				# Whether `/proc/meminfo` is available.
+				# @returns [Boolean] Whether the procfs memory information exists.
 				def self.supported?
 					File.exist?("/proc/meminfo")
 				end
 				
+				# Capture host memory from `/proc/meminfo`.
+				# @returns [Host::Memory | Nil] The captured host memory, if available.
 				def capture
 					content = File.read("/proc/meminfo") rescue nil
 					return nil unless content


### PR DESCRIPTION
## Summary

- document host-memory serialization methods
- document the Linux host-memory capture interface
- document the cgroup v1, cgroup v2, and `/proc/meminfo` readers

This addresses definitions reported by the current Decode documentation coverage check.

## Testing

- `bundle exec bake decode:index:coverage lib`
- `bundle exec rubocop`